### PR TITLE
display-number-of-commits-and-files

### DIFF
--- a/src/Service/RepositoryRecorder.php
+++ b/src/Service/RepositoryRecorder.php
@@ -54,7 +54,7 @@ class RepositoryRecorder
         foreach ($record->getPullRequests() as $index => $pr) {
 
             $record->addPullRequestDetail($index, $this->hoster->get($pr->url));
-            $record->addPullRequestStatus($index, $record->getPullRequestDetail($index)->statuses_url);
+            $record->addPullRequestStatus($index, $this->hoster->get($record->getPullRequestDetail($index)->statuses_url));
         }
         $this->storage->storeRecord($repositorySlug, $record);
     }

--- a/src/Service/Stats.php
+++ b/src/Service/Stats.php
@@ -49,10 +49,18 @@ class Stats
         /** @var \SplFileInfo $file */
         $stat = $record->getMetaFromName();
 
-        $stat['countPullRequests'] = $record->getNumberOfPullRequests();
-        $stat['agePullRequests'] = 0;
-        $stat['sum'] = 0;
-        $stat['weights'] = [];
+        $stat = array_merge(
+            $stat,
+            [
+                'countPullRequests' => $record->getNumberOfPullRequests(),
+                'agePullRequests' => 0,
+                'sum' => 0,
+                'commits' => 0,
+                'changedFiles' => 0,
+                'additions' => 0,
+                'deletions' => 0,
+            ]
+        );
 
         foreach ($record->getPullRequests() as $index => $pullRequest) {
 
@@ -63,6 +71,10 @@ class Stats
 
             $record->addPullRequestStats($index, $this->getPullRequestStats($pullRequest, $stat['date']));
             $stat['sum'] += $record->getPullRequestStats($index)['sum'];
+            $stat['commits'] += $pullRequest->data->commits;
+            $stat['changedFiles'] += $pullRequest->data->changed_files;
+            $stat['additions'] += $pullRequest->data->additions;
+            $stat['deletions'] += $pullRequest->data->deletions;
         }
         return $stat;
     }

--- a/src/Service/Stats.php
+++ b/src/Service/Stats.php
@@ -75,12 +75,13 @@ class Stats
      */
     public function getPullRequestStats($pullRequest, $dateString = 'now')
     {
+        $prDetail = $pullRequest->data;
         $score = [
-            'age'             => $this->measureWeight->getAge($pullRequest->data->created_at, $dateString),
-            'mergeable'       => $this->measureWeight->getNotMergeable($pullRequest->data->mergeable),
-            'mergeable_state' => $this->measureWeight->getMergeStateNotClean($pullRequest->data->mergeable_state),
-            'assignee'        => $this->measureWeight->getNoAssignee($pullRequest->assignee->login),
-            'body'            => $this->measureWeight->getEmptyBody($pullRequest->body),
+            'age'             => $this->measureWeight->getAge($prDetail->created_at, $dateString),
+            'mergeable'       => $this->measureWeight->getNotMergeable($prDetail->mergeable),
+            'mergeable_state' => $this->measureWeight->getMergeStateNotClean($prDetail->mergeable_state),
+            'assignee'        => $this->measureWeight->getNoAssignee($prDetail->assignee),
+            'body'            => $this->measureWeight->getEmptyBody($prDetail->body),
         ];
 
         $score['sum'] = array_sum($score);

--- a/src/Service/StatsWeight.php
+++ b/src/Service/StatsWeight.php
@@ -71,12 +71,12 @@ class StatsWeight
     }
 
     /**
-     * @param string $assignee
+     * @param \stdClass $assignee
      * @return int
      */
     public function getNoAssignee($assignee)
     {
-        if (empty($assignee)) {
+        if ($this->isAssigneeEmpty($assignee)) {
             return $this->config['no_assignee'];
         }
         return 0;
@@ -92,5 +92,20 @@ class StatsWeight
             return $this->config['empty_body'];
         }
         return 0;
+    }
+
+    /**
+     * @param $assignee
+     * @return bool
+     */
+    private function isAssigneeEmpty($assignee)
+    {
+        if (empty($assignee)) {
+            return true;
+        }
+        if (property_exists($assignee, 'login') == false) {
+            return true;
+        }
+        return  empty($assignee->login);
     }
 } 

--- a/views/repository.twig
+++ b/views/repository.twig
@@ -22,6 +22,10 @@
                     <th>Weight</th>
                     <th>Number of open PRs</th>
                     <th>Oldest PR</th>
+                    <th>Commits</th>
+                    <th>Changed files</th>
+                    <th>Additions</th>
+                    <th>Deletions</th>
                 </tr>
                 </thead>
                 <tr>
@@ -29,6 +33,10 @@
                     <td>{{ recordStats.sum }}</td>
                     <td>{{ recordStats.countPullRequests }}</td>
                     <td>{{ recordStats.agePullRequests }} days</td>
+                    <td>{{ recordStats.commits }}</td>
+                    <td>{{ recordStats.changedFiles }}</td>
+                    <td>{{ recordStats.additions }}</td>
+                    <td>{{ recordStats.deletions }}</td>
                 </tr>
             </table>
         </div>

--- a/views/repository.twig
+++ b/views/repository.twig
@@ -35,7 +35,7 @@
 
         <h2 class="sub-header">Open Pull Requests</h2>
         <div class="table-responsive">
-            <table class="table table-striped table-hover">
+            <table class="table table-striped table-hover table-condensed">
                 <thead>
                 <tr>
                     <th>Weight</th>
@@ -48,13 +48,16 @@
                     <th>CI State</th>
                     <th>Created By</th>
                     <th>Assigned To</th>
+                    <th># Commits</th>
+                    <th># Files</th>
+                    <th class="text-center">++ / --</th>
                 </tr>
                 </thead>
                 <tbody>
                 {% block pulls %}
                     {% for pullRequest in record.pullRequests %}
                         {% set pull = pullRequest.data %}
-                        {% set lastStatus = pullRequest.data_statuses_last is defined ? pullRequest.data_statuses_last : {'target_url':''} %}
+                        {% set lastStatus = pullRequest.data_statuses is defined ? pullRequest.data_statuses|first : {'target_url':'', 'state': 'none'} %}
                         {% set stats = pullRequest.data_stats %}
                         <tr>
                             <td>{{ pullRequest.data_stats is defined ? pullRequest.data_stats.sum : 0}}</td>
@@ -83,11 +86,21 @@
                                     title="{{ stats.mergeable_state > 0 ? 'Tests fail' : 'Integratable' }}">
                                 <a href="{{ lastStatus.target_url }}" title="State of integration">{{ pull.mergeable_state }}</a>
                             </td>
-                            <td>{{ pull.user.login }}</td>
+                            <td>{{ pull.user.login[:15] }}</td>
                             <td
                                     class="{{ stats.assignee > 0 ? 'danger' : 'success' }}"
                                     title="{{ stats.assignee > 0 ? 'PR is not assigned to someone, please assign.' : 'Someone cares' }}">
-                                {{ pull.assignee ? pull.assignee.login : '' }}
+                                {{ pull.assignee ? pull.assignee.login[:15] : '' }}
+                            </td>
+                            <td class="text-center">
+                                {{ "%02d"|format(pull.commits) }}
+                            </td>
+                            <td class="text-center">
+                                {{ "%02d"|format(pull.changed_files) }}
+                            </td>
+                            <td class="text-center">
+                                <span class="label label-success">{{ "%02d"|format(pull.additions) }}</span>
+                                <span class="label label-danger">{{ "%02d"|format(pull.deletions) }}</span>
                             </td>
                         </tr>
                     {% endfor %}

--- a/views/repository_stats.twig
+++ b/views/repository_stats.twig
@@ -25,4 +25,28 @@
             <td>{{ stat.sum }}</td>
         {% endfor %}
     </tr>
+    <tr>
+        <td>commits</td>
+        {% for date, stat in stats %}
+            <td>{{ stat.commits }}</td>
+        {% endfor %}
+    </tr>
+    <tr>
+        <td>changed files</td>
+        {% for date, stat in stats %}
+            <td>{{ stat.changedFiles }}</td>
+        {% endfor %}
+    </tr>
+    <tr>
+        <td>additions</td>
+        {% for date, stat in stats %}
+            <td>{{ stat.additions }}</td>
+        {% endfor %}
+    </tr>
+    <tr>
+        <td>deletions</td>
+        {% for date, stat in stats %}
+            <td>{{ stat.deletions }}</td>
+        {% endfor %}
+    </tr>
 </table>


### PR DESCRIPTION
Displaying number of commits and files, additions and deletions

These numbers are only displayed for stats-pr0n reasons, there are no conclusions to draw from those numbers !!!1!!11

![1884-o](https://cloud.githubusercontent.com/assets/182954/4021080/1aa89e3a-2ae0-11e4-9d7f-e9fa7f8d49ab.gif)
